### PR TITLE
fix: adjust case when no marketing optin field is configured

### DIFF
--- a/src/Sendinblue.php
+++ b/src/Sendinblue.php
@@ -283,6 +283,11 @@ class Sendinblue
             return true;
         }
 
+        // If no marketing optin field has been configured, we can assume that it is not needed and therefore allow the check to pass
+        if (!$marketing_optin) {
+            return true;
+        }
+
         // Return false as field is setup but has not been checked
         return false;
     }


### PR DESCRIPTION
I ran into an issue where a client didn't configure a marketing optin field, which returned `false` from `checkMarketingOptin()` and therefore prevented the recipient from being transferred to Sendinblue. I patched in a condition which prevents this and returns `true` if a marketing optin field should not be accounted for.

I figured i'll create a PR, just in case you want to merge this in. Currently I have patched it in for this specific project.